### PR TITLE
Cast dates written in the Common Era notation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 The `flexidate` library supports date parsing and normalization using the `FlexiDate` class. It provides functionality to:
 
-1. Cast dates according to the [Anno Domini](https://en.wikipedia.org/wiki/Anno_Domini) notation system (e.g., 399 BC, AD 417)
-1. Handle dates before  AD 1
+1. Cast dates according to the [Anno Domini](https://en.wikipedia.org/wiki/Anno_Domini) notation system (e.g., 399 BC, AD 417) as well as the Common Era notation system (e.g., 399 B.C.E, 417 CE)
+1. Handle dates before  AD 1 or 1 CE
 1. Cast imprecise dates (c.1860, 18??, fl. 1534, etc)
 1. Normalize dates to machine-readable data types
 1. Create sortable date objects
@@ -54,13 +54,20 @@ To case dates before Christ (i.e., Anno Domini or Common Era):
 >>> fd = parse('399 BC')
 >>> fd
 <class 'flexidate.FlexiDate'> -0399
+>>> fd.year
+'-0399'
 ```
 
 Or after:
 ``` python
->>> fd.year
-'-0399'
 >>> fd = parse('AD 417')
+>>> fd
+<class 'flexidate.FlexiDate'> 0417
+```
+
+Including with Common Era notation:
+``` python
+>>> fd = parse('417 CE')
 >>> fd
 <class 'flexidate.FlexiDate'> 0417
 ```
@@ -122,7 +129,7 @@ Patches are welcome. Please include additional tests where relevant.
 
 ## Run Tests
 
-Tests can be found in `flexidate/test_flexidate.py`. Run using `python flexidate/test_flexidate.py` or, for a full coverage report, `nosetests --no-skip --with-coverage`. 
+Tests can be found in `flexidate/test_flexidate.py`. Run using `python flexidate/test_flexidate.py` or, for a full coverage report, `nosetests --no-skip --with-coverage`.
 
 ## Package
 
@@ -131,7 +138,7 @@ To build locally: `python setup install`.
 
 ## TODO
 
-* Cast dates written in the [Common Era](https://en.wikipedia.org/wiki/Common_Era) notation system (e.g., 399 BCE, 417 CE)
+* ~~Cast dates written in the [Common Era](https://en.wikipedia.org/wiki/Common_Era) notation system (e.g., 399 BCE, 417 CE)~~
 
 
 # License

--- a/flexidate/__init__.py
+++ b/flexidate/__init__.py
@@ -229,8 +229,12 @@ class DateutilDateParser(DateParserBase):
 
         # various normalizations
         # TODO: call .lower() first
+        date = date.replace('B.C.E.', 'BC')
+        date = date.replace('BCE', 'BC')
         date = date.replace('B.C.', 'BC')
         date = date.replace('A.D.', 'AD')
+        date = date.replace('C.E.', 'AD')
+        date = date.replace('CE', 'AD')
 
         # deal with pre 0AD dates
         if date.startswith('-') or 'BC' in date or 'B.C.' in date:

--- a/flexidate/test_flexidate.py
+++ b/flexidate/test_flexidate.py
@@ -173,10 +173,10 @@ class TestDateParsers(object):
         in1 = '1768 A.D.'
         fd = parser.parse(in1)
         assert str(fd) == '1768', fd
-        #
-        # in1 = '1768 CE'
-        # fd = parser.parse(in1)
-        # assert str(fd) == '1768', fd
+        
+        in1 = '1768 CE'
+        fd = parser.parse(in1)
+        assert str(fd) == '1768', fd
 
         in1 = '1768 C.E.'
         fd = parser.parse(in1)

--- a/flexidate/test_flexidate.py
+++ b/flexidate/test_flexidate.py
@@ -173,6 +173,14 @@ class TestDateParsers(object):
         in1 = '1768 A.D.'
         fd = parser.parse(in1)
         assert str(fd) == '1768', fd
+        #
+        # in1 = '1768 CE'
+        # fd = parser.parse(in1)
+        # assert str(fd) == '1768', fd
+
+        in1 = '1768 C.E.'
+        fd = parser.parse(in1)
+        assert str(fd) == '1768', fd
 
         in1 = '-1850'
         fd = parser.parse(in1)
@@ -187,6 +195,14 @@ class TestDateParsers(object):
         assert str(fd) == '-0004', fd
 
         in1 = '4 B.C.'
+        fd = parser.parse(in1)
+        assert str(fd) == '-0004', fd
+
+        in1 = '4 BCE'
+        fd = parser.parse(in1)
+        assert str(fd) == '-0004', fd
+
+        in1 = '4 B.C.E.'
         fd = parser.parse(in1)
         assert str(fd) == '-0004', fd
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ certifi==2018.11.29
 chardet==3.0.4
 codecov==2.0.15
 coverage==4.5.2
-flexidate==1.2
 idna==2.8
 nose==1.3.7
 python-dateutil==2.8.0


### PR DESCRIPTION
Fixes #10 
- Adds B.C.E./BCE/C.E./CE to conditions checked in DateutilDateParser
- Updates tests/docs/etc.